### PR TITLE
chore: release main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14003,11 +14003,11 @@
 		},
 		"packages/event-bus-connector-local": {
 			"name": "@twin.org/event-bus-connector-local",
-			"version": "0.0.0",
+			"version": "0.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "^0.0.1",
-				"@twin.org/event-bus-models": "^0.0.0",
+				"@twin.org/event-bus-models": "^0.0.1",
 				"@twin.org/logging-models": "^0.0.1",
 				"@twin.org/nameof": "^0.0.1"
 			},
@@ -14055,7 +14055,7 @@
 		},
 		"packages/event-bus-models": {
 			"name": "@twin.org/event-bus-models",
-			"version": "0.0.0",
+			"version": "0.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "^0.0.1",
@@ -14101,12 +14101,12 @@
 		},
 		"packages/event-bus-service": {
 			"name": "@twin.org/event-bus-service",
-			"version": "0.0.0",
+			"version": "0.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/api-models": "^0.0.1",
 				"@twin.org/core": "^0.0.1",
-				"@twin.org/event-bus-models": "^0.0.0",
+				"@twin.org/event-bus-models": "^0.0.1",
 				"@twin.org/logging-models": "^0.0.1",
 				"@twin.org/nameof": "^0.0.1"
 			},
@@ -14114,7 +14114,7 @@
 				"@twin.org/api-processors": "^0.0.1",
 				"@twin.org/api-server-fastify": "^0.0.1",
 				"@twin.org/entity-storage-connector-memory": "^0.0.1",
-				"@twin.org/event-bus-connector-local": "^0.0.0",
+				"@twin.org/event-bus-connector-local": "^0.0.1",
 				"@twin.org/logging-connector-entity-storage": "^0.0.1-next.25",
 				"@twin.org/nameof-transformer": "^0.0.1",
 				"@twin.org/nameof-vitest-plugin": "^0.0.1",
@@ -14157,13 +14157,13 @@
 		},
 		"packages/event-bus-socket-client": {
 			"name": "@twin.org/event-bus-socket-client",
-			"version": "0.0.0",
+			"version": "0.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/api-core": "^0.0.1",
 				"@twin.org/api-models": "^0.0.1",
 				"@twin.org/core": "^0.0.1",
-				"@twin.org/event-bus-models": "^0.0.0",
+				"@twin.org/event-bus-models": "^0.0.1",
 				"@twin.org/logging-models": "^0.0.1",
 				"@twin.org/nameof": "^0.0.1"
 			},
@@ -14172,8 +14172,8 @@
 				"@twin.org/api-server-fastify": "^0.0.1",
 				"@twin.org/entity-storage-connector-memory": "^0.0.1",
 				"@twin.org/entity-storage-models": "^0.0.1",
-				"@twin.org/event-bus-connector-local": "^0.0.0",
-				"@twin.org/event-bus-service": "^0.0.0",
+				"@twin.org/event-bus-connector-local": "^0.0.1",
+				"@twin.org/event-bus-service": "^0.0.1",
 				"@twin.org/logging-connector-entity-storage": "^0.0.1-next.25",
 				"@twin.org/logging-models": "^0.0.1",
 				"@twin.org/nameof-transformer": "^0.0.1",

--- a/packages/event-bus-connector-local/docs/changelog.md
+++ b/packages/event-bus-connector-local/docs/changelog.md
@@ -1,5 +1,20 @@
 # @twin.org/event-bus-connector-local - Changelog
 
+## 0.0.1 (2025-07-04)
+
+
+### Features
+
+* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
+* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/event-bus-models bumped from ^0.0.0 to ^0.0.1
+
 ## [0.0.1-next.11](https://github.com/twinfoundation/event-bus/compare/event-bus-connector-local-v0.0.1-next.10...event-bus-connector-local-v0.0.1-next.11) (2025-06-12)
 
 

--- a/packages/event-bus-connector-local/package.json
+++ b/packages/event-bus-connector-local/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/event-bus-connector-local",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"description": "Event bus connector implementation local communication",
 	"repository": {
 		"type": "git",
@@ -30,7 +30,7 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/event-bus-models": "^0.0.0",
+		"@twin.org/event-bus-models": "^0.0.1",
 		"@twin.org/core": "^0.0.1",
 		"@twin.org/nameof": "^0.0.1",
 		"@twin.org/logging-models": "^0.0.1"

--- a/packages/event-bus-models/docs/changelog.md
+++ b/packages/event-bus-models/docs/changelog.md
@@ -1,5 +1,14 @@
 # @twin.org/event-bus-models - Changelog
 
+## 0.0.1 (2025-07-04)
+
+
+### Features
+
+* improve comment ([23e86ec](https://github.com/twinfoundation/event-bus/commit/23e86ecb0ad7cc94b0ebf414e51c7ac1e7f0afd3))
+* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
+* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))
+
 ## [0.0.1-next.11](https://github.com/twinfoundation/event-bus/compare/event-bus-models-v0.0.1-next.10...event-bus-models-v0.0.1-next.11) (2025-06-12)
 
 

--- a/packages/event-bus-models/package.json
+++ b/packages/event-bus-models/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/event-bus-models",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"description": "Models which define the structure of the event bus contracts and connectors",
 	"repository": {
 		"type": "git",

--- a/packages/event-bus-service/docs/changelog.md
+++ b/packages/event-bus-service/docs/changelog.md
@@ -1,5 +1,22 @@
 # @twin.org/event-bus-service - Changelog
 
+## 0.0.1 (2025-07-04)
+
+
+### Features
+
+* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
+* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/event-bus-models bumped from ^0.0.0 to ^0.0.1
+  * devDependencies
+    * @twin.org/event-bus-connector-local bumped from ^0.0.0 to ^0.0.1
+
 ## [0.0.1-next.11](https://github.com/twinfoundation/event-bus/compare/event-bus-service-v0.0.1-next.10...event-bus-service-v0.0.1-next.11) (2025-06-12)
 
 

--- a/packages/event-bus-service/package.json
+++ b/packages/event-bus-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/event-bus-service",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"description": "Event bus service implementation using web sockets",
 	"repository": {
 		"type": "git",
@@ -30,7 +30,7 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/event-bus-models": "^0.0.0",
+		"@twin.org/event-bus-models": "^0.0.1",
 		"@twin.org/api-models": "^0.0.1",
 		"@twin.org/core": "^0.0.1",
 		"@twin.org/nameof": "^0.0.1",
@@ -40,7 +40,7 @@
 		"@twin.org/api-processors": "^0.0.1",
 		"@twin.org/api-server-fastify": "^0.0.1",
 		"@twin.org/entity-storage-connector-memory": "^0.0.1",
-		"@twin.org/event-bus-connector-local": "^0.0.0",
+		"@twin.org/event-bus-connector-local": "^0.0.1",
 		"@twin.org/logging-connector-entity-storage": "^0.0.1-next.25",
 		"@twin.org/nameof-transformer": "^0.0.1",
 		"@twin.org/nameof-vitest-plugin": "^0.0.1",

--- a/packages/event-bus-socket-client/docs/changelog.md
+++ b/packages/event-bus-socket-client/docs/changelog.md
@@ -1,5 +1,23 @@
 # @twin.org/event-bus-socket-client - Changelog
 
+## 0.0.1 (2025-07-04)
+
+
+### Features
+
+* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
+* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/event-bus-models bumped from ^0.0.0 to ^0.0.1
+  * devDependencies
+    * @twin.org/event-bus-connector-local bumped from ^0.0.0 to ^0.0.1
+    * @twin.org/event-bus-service bumped from ^0.0.0 to ^0.0.1
+
 ## [0.0.1-next.11](https://github.com/twinfoundation/event-bus/compare/event-bus-socket-client-v0.0.1-next.10...event-bus-socket-client-v0.0.1-next.11) (2025-06-12)
 
 

--- a/packages/event-bus-socket-client/package.json
+++ b/packages/event-bus-socket-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/event-bus-socket-client",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"description": "Event bus component implementation which can connect to socket endpoints",
 	"repository": {
 		"type": "git",
@@ -33,7 +33,7 @@
 		"@twin.org/api-core": "^0.0.1",
 		"@twin.org/api-models": "^0.0.1",
 		"@twin.org/core": "^0.0.1",
-		"@twin.org/event-bus-models": "^0.0.0",
+		"@twin.org/event-bus-models": "^0.0.1",
 		"@twin.org/logging-models": "^0.0.1",
 		"@twin.org/nameof": "^0.0.1"
 	},
@@ -44,8 +44,8 @@
 		"@twin.org/logging-connector-entity-storage": "^0.0.1-next.25",
 		"@twin.org/entity-storage-models": "^0.0.1",
 		"@twin.org/entity-storage-connector-memory": "^0.0.1",
-		"@twin.org/event-bus-connector-local": "^0.0.0",
-		"@twin.org/event-bus-service": "^0.0.0",
+		"@twin.org/event-bus-connector-local": "^0.0.1",
+		"@twin.org/event-bus-service": "^0.0.1",
 		"@twin.org/nameof-transformer": "^0.0.1",
 		"@twin.org/nameof-vitest-plugin": "^0.0.1",
 		"@vitest/coverage-v8": "3.2.3",

--- a/release/release-please-manifest.prod.json
+++ b/release/release-please-manifest.prod.json
@@ -1,6 +1,6 @@
 {
-	"packages/event-bus-models": "0.0.0",
-	"packages/event-bus-connector-local": "0.0.0",
-	"packages/event-bus-service": "0.0.0",
-	"packages/event-bus-socket-client": "0.0.0"
+	"packages/event-bus-models": "0.0.1",
+	"packages/event-bus-connector-local": "0.0.1",
+	"packages/event-bus-service": "0.0.1",
+	"packages/event-bus-socket-client": "0.0.1"
 }


### PR DESCRIPTION
chore: prod release prepared
---


<details><summary>event-bus-connector-local: 0.0.1</summary>

## 0.0.1 (2025-07-04)


### Features

* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/event-bus-models bumped from ^0.0.0 to ^0.0.1
</details>

<details><summary>event-bus-models: 0.0.1</summary>

## 0.0.1 (2025-07-04)


### Features

* improve comment ([23e86ec](https://github.com/twinfoundation/event-bus/commit/23e86ecb0ad7cc94b0ebf414e51c7ac1e7f0afd3))
* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))
</details>

<details><summary>event-bus-service: 0.0.1</summary>

## 0.0.1 (2025-07-04)


### Features

* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/event-bus-models bumped from ^0.0.0 to ^0.0.1
  * devDependencies
    * @twin.org/event-bus-connector-local bumped from ^0.0.0 to ^0.0.1
</details>

<details><summary>event-bus-socket-client: 0.0.1</summary>

## 0.0.1 (2025-07-04)


### Features

* update dependencies ([a313000](https://github.com/twinfoundation/event-bus/commit/a313000b9c3264e8ed2602622219be2cefcf0474))
* use shared store mechanism ([#2](https://github.com/twinfoundation/event-bus/issues/2)) ([1ded106](https://github.com/twinfoundation/event-bus/commit/1ded10684e8fab4a5138231e9f2ab49e43590f00))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/event-bus-models bumped from ^0.0.0 to ^0.0.1
  * devDependencies
    * @twin.org/event-bus-connector-local bumped from ^0.0.0 to ^0.0.1
    * @twin.org/event-bus-service bumped from ^0.0.0 to ^0.0.1
</details>

---
This PR was generated by the prepare-release GHA